### PR TITLE
リンクの修正

### DIFF
--- a/docs/archive/4_2_1/belongs_to.md
+++ b/docs/archive/4_2_1/belongs_to.md
@@ -69,4 +69,4 @@ create_association!(attributes = {}) | 新しいオブジェクトを生成し�
     belongs_to :user, foreign_key => "blog_id"
 
 ### ソースコード
-    * [GitHub](https://github.com/rails/rails/blob/0af3dd4438047d8c5783dff1cfcf9c696b44bdff/activerecord/lib/active_record/associations.rb#L1514)
+* [GitHub](https://github.com/rails/rails/blob/0af3dd4438047d8c5783dff1cfcf9c696b44bdff/activerecord/lib/active_record/associations.rb#L1514)

--- a/docs/archive/5_2_4_1/page/belongs_to.md
+++ b/docs/archive/5_2_4_1/page/belongs_to.md
@@ -68,4 +68,4 @@ layout: archive_page
     belongs_to :account, default: -> { company.account }
 
 ### ソースコード
-    * [GitHub](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activerecord/lib/active_record/associations.rb#L1653)
+* [GitHub](https://github.com/rails/rails/blob/ac30e389ecfa0e26e3d44c1eda8488ddf63b3ecc/activerecord/lib/active_record/associations.rb#L1653)

--- a/docs/page/belongs_to.md
+++ b/docs/page/belongs_to.md
@@ -68,4 +68,4 @@ layout: page
     belongs_to :account, default: -> { company.account }
 
 ### ソースコード
-    * [GitHub](https://github.com/rails/rails/blob/f33d52c95217212cbacc8d5e44b5a8e3cdc6f5b3/activerecord/lib/active_record/associations.rb#L1657)
+* [GitHub](https://github.com/rails/rails/blob/f33d52c95217212cbacc8d5e44b5a8e3cdc6f5b3/activerecord/lib/active_record/associations.rb#L1657)


### PR DESCRIPTION
インデントが入っていることでリンクとして解釈されていない箇所を修正しました。

- https://railsdoc.com/archive/5_2_4_1/association#%E3%82%BD%E3%83%BC%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89
- https://railsdoc.com/association#%E3%82%BD%E3%83%BC%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89